### PR TITLE
Update banner

### DIFF
--- a/theme_overrides/main.html
+++ b/theme_overrides/main.html
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block announce %}
-  <p class="announce">The GBFS Documentation Platform got some updates! Read the blog post <a href="https://share.mobilitydata.org/gbfs-org-release" target="_blank">here</a>.  🚀 </p>
+  <p class="announce">MobilityData is the new home of GBFS! Read the press release <a href="https://share.mobilitydata.org/mobility-data-new-home-for-gbfs" target="_blank">here</a>.  🚀 </p>
 {% endblock %}


### PR DESCRIPTION
Update banner to link to press release announcing MobilityData as the new home of GBFS, replacing prior blog post about changes to the site. 