### PR TITLE
Update link to slack

### DIFF
--- a/docs/learn/faq.md
+++ b/docs/learn/faq.md
@@ -195,6 +195,6 @@ MobilityData is a non-profit organization that improves and extends data formats
 There are a number of ways you can get involved with our organization and the Shared Mobility community! 
 
 - Learn more about us: [www.mobilitydata.org](https://www.mobilitydata.org)
-- Join our slack: [bit.ly/mobilitydata-slack](https://bit.ly/mobilitydata-slack)
+- Join our slack: [https://share.mobilitydata.org/slack](https://share.mobilitydata.org/slack)
 - Join us on Github: [github.com/NABSA/gbfs](https://github.com/NABSA/gbfs)
 - Become a member: [bit.ly/Membership-form-2021](https://bit.ly/Membership-form-2021)

--- a/docs/learn/white-papers/data-policy-europe.md
+++ b/docs/learn/white-papers/data-policy-europe.md
@@ -4,7 +4,7 @@
 ## Overview
 Securing access to mobility data is an important part of a shared mobility program. Public access to mobility data builds trust in mobility programs and increases shared mobility adoption. Writing effective policy can ensure that mobility data is both accurate and accessible.
 
-This report is intended primarily for individuals responsible for shared mobility procurement and policies at cities or other local authorities. The report provides a foundational understanding of how GBFS supports seamless, sustainable mobility options and how to leverage open data’s potential when writing policy that can influence shared mobility adoption and practice. This report is applicable primarily to cities in Europe. For American stakeholders , see our report on [data policy ofr American cities](href="data-policy.md").
+This report is intended primarily for individuals responsible for shared mobility procurement and policies at cities or other local authorities. The report provides a foundational understanding of how GBFS supports seamless, sustainable mobility options and how to leverage open data’s potential when writing policy that can influence shared mobility adoption and practice. This report is applicable primarily to cities in Europe. For American stakeholders , see our report on [data policy for American cities](href="data-policy.md").
 
 
 ### GBFS makes it easy for travelers to find and use shared mobility.
@@ -199,7 +199,7 @@ GBFS is the only open data standard, used internationally, to be recognized by C
 ## Useful links
 
 * [GBFS Repo on GitHub](https://github.com/NABSA/gbfs)
-* [GBFS Public Slack Channel](https://bit.ly/mobilitydata-slack)
+* [GBFS Public Slack Channel](https://share.mobilitydata.org/slack)
 * [NeTEx](https://data4pt.org/wiki/NeTEX)
 * [SIRI](https://data4pt.org/wiki/SIRI)
 

--- a/docs/learn/white-papers/data-policy.md
+++ b/docs/learn/white-papers/data-policy.md
@@ -182,7 +182,7 @@ GBFS has been developed and tested under a consensus model to ensure that data d
 
 ## **Useful links**
 * [GBFS Repo on GitHub](https://github.com/NABSA/gbfs)
-* [GBFS Public Slack Channel](https://mobilitydata-io.herokuapp.com/)
+* [GBFS Public Slack Channel](https://share.mobilitydata.org/slack)
 
 MobilityData Shared Mobility team email: <sharedmobility@mobilitydata.org>
 

--- a/docs/participate.md
+++ b/docs/participate.md
@@ -20,7 +20,7 @@ The full text of the [project governance and change process](https://github.com/
 
 Comments or questions can be addressed to the community by [opening an issue](https://github.com/MobilityData/gbfs/issues) on the project GitHub repository. Proposals for changes or additions to the specification can be made through GitHub [pull requests](https://github.com/MobilityData/gbfs/pulls).
 
-Questions can also be addressed to the community via the [public GBFS Slack channel](https://bit.ly/mobilitydata-slack) or to the shared mobility staff at MobilityData: <sharedmobility@mobilitydata.org>.
+Questions can also be addressed to the community via the [public GBFS Slack channel](https://share.mobilitydata.org/slack) or to the shared mobility staff at MobilityData: <sharedmobility@mobilitydata.org>.
 
 <hr>
 
@@ -38,7 +38,7 @@ Alternatively, you can provide feedback on this site by using the form below.
 
 - Specification and technical questions: [sharedmobility@mobilitydata.org](mailto:sharedmobility@mobilitydata.org)
 - Documentation needs: [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org)
-- Join MobilityData's public [slack channel](https://bit.ly/mobilitydata-slack)
+- Join MobilityData's public [slack channel](https://share.mobilitydata.org/slack)
 
 <hr>
 

--- a/docs/specification/process.md
+++ b/docs/specification/process.md
@@ -10,7 +10,7 @@ To manage the change process, the following guidelines have been established.
 * After 7 calendar days, The Advocate can call for a vote. Should The Advocate not call a vote or respond to comments from the community for a period of 30 full calendar days, anyone in the community can call for a vote. Vote lasts the minimum period sufficient to cover 10 full calendar days. Voting ends at 23:59:59 UTC. The vote announcement must conform to this template: 
     * *I hereby call a vote on this proposal. Voting will be open for 10 full calendar days until 11:59PM UTC on X.<br /> Please vote for or against the proposal, and include the organization for which you are voting in your comment. <br /> Please note if you can commit to implementing the proposal.*
 
-* The person calling for the vote should announce the vote in the [GBFS Slack channel](https://mobilitydata-io.slack.com) with a link to the PR. The message should conform to this template:
+* The person calling for the vote should announce the vote in the [GBFS Slack channel](https://share.mobilitydata.org/slack) with a link to the PR. The message should conform to this template:
     * *A vote has been called on PR # [title of PR] (link to PR). This vote will be open for 10 full calendar days, until 11:59PM UTC on X. Please vote for or against the proposal on GitHub.*
 * MobilityData will both comment on the PR on GitHub and send a reminder in the GBFS Slack channel when there are 2 calendar days remaining on the vote. The reminder should conform to this template: 
     * **Slack:** *Voting on PR # [title of PR] (link to PR) closes in 2 calendar days. Please vote for or against the proposal on GitHub.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/mobilitydata
     - icon: fontawesome/brands/slack
-      link: https://bit.ly/mobilitydata-slack
+      link: https://share.mobilitydata.org/slack
 markdown_extensions:
   - attr_list
   - md_in_html


### PR DESCRIPTION
As mentioned in #24, the links used to connect to slack is out of date. This PR updates to those links to https://share.mobilitydata.org/slack

(+ fixes one typo found)