### PR TITLE
gbfs.mobilitydata.org --> gbfs.org

### DIFF
--- a/theme_overrides/main.html
+++ b/theme_overrides/main.html
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block announce %}
-  <p class="announce">We want to know how you use GBFS, take the Annual Survey <a href="https://share.mobilitydata.org/annual-GBFS-survey" target="_blank">here</a>.  🚀 </p>
+  <p class="announce"> We are thrilled to announce that gbfs.mobilitydata.org is now gbfs.org 🚀 </p>
 {% endblock %}


### PR DESCRIPTION
MobilityData has acquired the gbfs.org domain, this PR updates the announcement banner to let users know. 

<img width="1328" alt="image" src="https://github.com/MobilityData/gbfs.mobilitydata.org/assets/2423604/4b23b34a-9275-4c58-909e-5d875c86f787">