### PR TITLE
Sync GBFS spec typo

### DIFF
--- a/docs/specification/reference.md
+++ b/docs/specification/reference.md
@@ -1249,8 +1249,8 @@ Field Name | REQUIRED | Type | Defines
 \-&nbsp;`times` | OPTIONAL | Array | Array of objects with the fields `start` and `end` indicating when the alert is in effect (for example, when the system or station is actually closed, or when a station is scheduled to be moved).
 &emsp;\-&nbsp;`start` | Conditionally REQUIRED | Timestamp | REQUIRED if `times` array is defined. Start time of the alert.
 &emsp;\-&nbsp;`end` | OPTIONAL | Timestamp | End time of the alert. If there is currently no end time planned for the alert, this can be omitted.
-\-&nbsp;`station_ids` | OPTIONAL | Array | If this is an alert that affects one or more stations, include their ID(s). Otherwise omit this field. If both `station_id` and `region_id` are omitted, this alert affects the entire system.
-\-&nbsp;`region_ids` | OPTIONAL | Array | If this system has regions, and if this alert only affects certain regions, include their ID(s). Otherwise, omit this field. If both `station_id`s and `region_id`s are omitted, this alert affects the entire system.
+\-&nbsp;`station_ids` | OPTIONAL | Array | If this is an alert that affects one or more stations, include their ID(s). Otherwise omit this field. If both `station_ids` and `region_ids` are omitted, this alert affects the entire system.
+\-&nbsp;`region_ids` | OPTIONAL | Array | If this system has regions, and if this alert only affects certain regions, include their ID(s). Otherwise, omit this field. If both `station_ids` and `region_ids` are omitted, this alert affects the entire system.
 \-&nbsp; `url` <br/>*(as of v3.0-RC)* | OPTIONAL | Array&lt;Localized String&gt; | URL where the customer can learn more information about this alert.
 \-&nbsp; `summary` <br/>*(as of v3.0-RC)*  | Yes | Array&lt;Localized String&gt; | A short summary of this alert to be displayed to the customer.
 \-&nbsp; `description` <br/>*(as of v3.0-RC)*  | OPTIONAL | Array&lt;Localized String&gt; | Detailed description of the alert.


### PR DESCRIPTION
Change:
- Fix typos in system_alerts.json which was fixed in the spec in https://github.com/MobilityData/gbfs/pull/540

Fixes https://github.com/MobilityData/gbfs.mobilitydata.org/issues/38