### PR TITLE
Update URL to governance process

### DIFF
--- a/docs/participate.md
+++ b/docs/participate.md
@@ -12,7 +12,7 @@ All change proposals are subject to the GBFS governance process.
 - When a vote passes, the change becomes part of a Release Candidate.
 - Once both a data producer and a date consumer have implemented the change, the Release Candidate becomes an official version release.
 
-The full text of the [project governance and change process](https://github.com/MobilityData/gbfs#governance--overview-of-the-change-process) can be found on the project GitHub repository.
+The full text of the [project governance process](https://github.com/MobilityData/gbfs/blob/master/governance.md) can be found on the project GitHub repository.
 
 <hr>
 


### PR DESCRIPTION
The governance process was moved to a separate file in https://github.com/MobilityData/gbfs/pull/521.

This PR updates the governance process URL on https://gbfs.org/participate/ to the new file (https://github.com/MobilityData/gbfs/blob/master/governance.md).

<img width="1800" alt="Screenshot 2023-09-27 at 14 12 52" src="https://github.com/MobilityData/gbfs.mobilitydata.org/assets/2423604/26884284-db9f-41d6-b0bc-2153c57f8b67">